### PR TITLE
LinkedChannels & ContentOwner > Models

### DIFF
--- a/examples/list_channels_of_content_owner.php
+++ b/examples/list_channels_of_content_owner.php
@@ -6,9 +6,9 @@ $service_account = file_get_contents(__DIR__ . '/service_account.json');
 
 $contentOwner = \Tubecode\Factory::create($service_account, [], "YOUR CONTENT OWNER ID");
 
-echo "Count: " . $contentOwner->partneredChannels()->count() . PHP_EOL;
+echo "Count: " . $contentOwner->linkedChannels()->count() . PHP_EOL;
 
-foreach($contentOwner->partneredChannels()->all() as $channel)
+foreach($contentOwner->linkedChannels()->all() as $channel)
 {
     echo "ID: {$channel->getId()}" . PHP_EOL;
 }

--- a/src/Tubecode/Collections/ContentOwners.php
+++ b/src/Tubecode/Collections/ContentOwners.php
@@ -2,7 +2,7 @@
 
 namespace Tubecode\Collections;
 
-use Tubecode\ContentOwner;
+use Tubecode\Models\ContentOwner;
 use Tubecode\Contracts\ContentOwnerInterface;
 
 class ContentOwners

--- a/src/Tubecode/Collections/ContentOwners.php
+++ b/src/Tubecode/Collections/ContentOwners.php
@@ -51,6 +51,7 @@ class ContentOwners
     }
 
     /**
+     * @param null $id
      * @return ContentOwnerInterface
      */
     public function get($id = null)

--- a/src/Tubecode/Collections/LinkedChannels.php
+++ b/src/Tubecode/Collections/LinkedChannels.php
@@ -2,7 +2,7 @@
 
 namespace Tubecode\Collections;
 
-use Tubecode\ContentOwner;
+use Tubecode\Models\ContentOwner;
 use Tubecode\Contracts\ContentOwnerInterface;
 use Tubecode\Models\Channel;
 

--- a/src/Tubecode/Collections/LinkedChannels.php
+++ b/src/Tubecode/Collections/LinkedChannels.php
@@ -6,7 +6,7 @@ use Tubecode\ContentOwner;
 use Tubecode\Contracts\ContentOwnerInterface;
 use Tubecode\Models\Channel;
 
-class PartneredChannels
+class LinkedChannels
 {
     private $channels = [];
 

--- a/src/Tubecode/ContentOwner.php
+++ b/src/Tubecode/ContentOwner.php
@@ -2,7 +2,7 @@
 
 namespace Tubecode;
 
-use Tubecode\Collections\PartneredChannels;
+use Tubecode\Collections\LinkedChannels;
 use Tubecode\Contracts\ContentOwnerInterface;
 
 class ContentOwner implements ContentOwnerInterface
@@ -59,9 +59,9 @@ class ContentOwner implements ContentOwnerInterface
         return $this->primaryNotificationEmails;
     }
 
-    public function partneredChannels()
+    public function linkedChannels()
     {
-        return new PartneredChannels($this->client, $this);
+        return new LinkedChannels($this->client, $this);
     }
 
     /**

--- a/src/Tubecode/Models/ContentOwner.php
+++ b/src/Tubecode/Models/ContentOwner.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tubecode;
+namespace Tubecode\Models;
 
 use Tubecode\Collections\LinkedChannels;
 use Tubecode\Contracts\ContentOwnerInterface;


### PR DESCRIPTION
Changed naming from PartneredChannels to LinkedChannels. Not every content owner is an MCN, and therefore. I find the term Partnered channels a bit weird.